### PR TITLE
1.12 shoutcast fixes

### DIFF
--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -13,14 +13,13 @@
 
 unsigned int kBufferFrames = 32768; // 743 ms @ 44100 Hz
 
-EngineNetworkStream::EngineNetworkStream(double sampleRate,
-                                         int numOutputChannels,
+EngineNetworkStream::EngineNetworkStream(int numOutputChannels,
                                          int numInputChannels)
     : m_pOutputFifo(NULL),
       m_pInputFifo(NULL),
       m_numOutputChannels(numOutputChannels),
       m_numInputChannels(numInputChannels),
-      m_sampleRate(sampleRate),
+      m_sampleRate(0),
       m_streamStartTimeMs(-1),
       m_streamFramesWritten(0),
       m_streamFramesRead(0) {
@@ -40,7 +39,8 @@ EngineNetworkStream::~EngineNetworkStream() {
     delete m_pInputFifo;
 }
 
-void EngineNetworkStream::startStream() {
+void EngineNetworkStream::startStream(double sampleRate) {
+    m_sampleRate = sampleRate;
     m_streamStartTimeMs = getNetworkTimeMs();
     m_streamFramesWritten = 0;
 }

--- a/src/engine/sidechain/enginenetworkstream.h
+++ b/src/engine/sidechain/enginenetworkstream.h
@@ -4,6 +4,8 @@
 #include "util/types.h"
 #include "util/fifo.h"
 
+class SideChainWorker;
+
 class EngineNetworkStream {
   public:
     EngineNetworkStream(int numOutputChannels,
@@ -33,6 +35,10 @@ class EngineNetworkStream {
 
     static qint64 getNetworkTimeMs();
 
+    void addWorker(QSharedPointer<SideChainWorker> pWorker) {
+        m_pWorker = pWorker;
+    }
+
   private:
     FIFO<CSAMPLE>* m_pOutputFifo;
     FIFO<CSAMPLE>* m_pInputFifo;
@@ -42,6 +48,7 @@ class EngineNetworkStream {
     qint64 m_streamStartTimeMs;
     qint64 m_streamFramesWritten;
     qint64 m_streamFramesRead;
+    QSharedPointer<SideChainWorker> m_pWorker;
 };
 
 #endif /* ENGINENETWORKSTREAM_H_ */

--- a/src/engine/sidechain/enginenetworkstream.h
+++ b/src/engine/sidechain/enginenetworkstream.h
@@ -6,12 +6,11 @@
 
 class EngineNetworkStream {
   public:
-    EngineNetworkStream(double sampleRate,
-            int numOutputChannels,
+    EngineNetworkStream(int numOutputChannels,
             int numInputChannels);
     virtual ~EngineNetworkStream();
 
-    void startStream();
+    void startStream(double sampleRate);
     void stopStream();
 
     int getWriteExpected();
@@ -23,6 +22,14 @@ class EngineNetworkStream {
 
     qint64 getStreamTimeMs();
     qint64 getStreamTimeFrames();
+
+    int getNumOutputChannels() {
+        return m_numOutputChannels;
+    }
+
+    int getNumInputChannels() {
+        return m_numInputChannels;
+    }
 
     static qint64 getNetworkTimeMs();
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -200,16 +200,16 @@ void MixxxMainWindow::initalize(QApplication* pApp, const CmdlineArgs& args) {
 
     launchProgress(8);
 
-    m_pRecordingManager = new RecordingManager(m_pConfig, m_pEngine);
-#ifdef __SHOUTCAST__
-    m_pShoutcastManager = new ShoutcastManager(m_pConfig, m_pEngine);
-#endif
-
     // Initialize player device
     // while this is created here, setupDevices needs to be called sometime
     // after the players are added to the engine (as is done currently) -- bkgood
     // (long)
     m_pSoundManager = new SoundManager(m_pConfig, m_pEngine);
+
+    m_pRecordingManager = new RecordingManager(m_pConfig, m_pEngine);
+#ifdef __SHOUTCAST__
+    m_pShoutcastManager = new ShoutcastManager(m_pConfig, m_pSoundManager);
+#endif
 
     launchProgress(11);
     // TODO(rryan): Fold microphone and aux creation into a manager

--- a/src/shoutcast/shoutcastmanager.cpp
+++ b/src/shoutcast/shoutcastmanager.cpp
@@ -3,14 +3,19 @@
 #include "shoutcast/defs_shoutcast.h"
 #include "engine/sidechain/engineshoutcast.h"
 #include "engine/sidechain/enginesidechain.h"
+#include "engine/sidechain/enginenetworkstream.h"
 #include "engine/enginemaster.h"
+#include "soundmanager.h"
 
 ShoutcastManager::ShoutcastManager(ConfigObject<ConfigValue>* pConfig,
-                                   EngineMaster* pEngine)
+                                   SoundManager* pSoundManager)
         : m_pConfig(pConfig) {
-    EngineSideChain* pSidechain = pEngine->getSideChain();
-    if (pSidechain) {
-        pSidechain->addSideChainWorker(new EngineShoutcast(pConfig));
+    QSharedPointer<EngineNetworkStream> pNetworkStream =
+            pSoundManager->getNetworkStream();
+    if (!pNetworkStream.isNull()) {
+        QSharedPointer<SideChainWorker> pWorker(
+                new EngineShoutcast(pConfig));
+        pNetworkStream->addWorker(pWorker);
     }
 }
 

--- a/src/shoutcast/shoutcastmanager.h
+++ b/src/shoutcast/shoutcastmanager.h
@@ -5,12 +5,13 @@
 
 #include "configobject.h"
 
-class EngineMaster;
+class SoundManager;
 
 class ShoutcastManager : public QObject {
     Q_OBJECT
   public:
-    ShoutcastManager(ConfigObject<ConfigValue>* pConfig, EngineMaster* pEngine);
+    ShoutcastManager(ConfigObject<ConfigValue>* pConfig,
+                     SoundManager* pSoundManager);
     virtual ~ShoutcastManager();
 
     // Returns true if the Shoutcast connection is enabled. Note this only

--- a/src/sounddevice.cpp
+++ b/src/sounddevice.cpp
@@ -25,7 +25,7 @@
 #include "util/debug.h"
 #include "sampleutil.h"
 
-SoundDevice::SoundDevice(ConfigObject<ConfigValue> * config, SoundManager * sm)
+SoundDevice::SoundDevice(ConfigObject<ConfigValue>* config, SoundManager* sm)
         : m_pConfig(config),
           m_pSoundManager(sm),
           m_strInternalName("Unknown Soundcard"),

--- a/src/sounddevicenetwork.h
+++ b/src/sounddevicenetwork.h
@@ -15,8 +15,8 @@ class EngineNetworkStream;
 class SoundDeviceNetwork : public SoundDevice {
   public:
     SoundDeviceNetwork(ConfigObject<ConfigValue> *config,
-                         SoundManager *sm,
-                         unsigned int devIndex);
+                       SoundManager *sm,
+                       QSharedPointer<EngineNetworkStream> pNetworkStream);
     virtual ~SoundDeviceNetwork();
 
     virtual Result open(bool isClkRefDevice, int syncBuffers);
@@ -30,7 +30,7 @@ class SoundDeviceNetwork : public SoundDevice {
     }
 
   private:
-    EngineNetworkStream* m_pNetworkStream;
+    QSharedPointer<EngineNetworkStream> m_pNetworkStream;
     FIFO<CSAMPLE>* m_outputFifo;
     FIFO<CSAMPLE>* m_inputFifo;
     bool m_outputDrift;

--- a/src/soundmanager.cpp
+++ b/src/soundmanager.cpp
@@ -33,6 +33,7 @@
 #include "vinylcontrol/defs_vinylcontrol.h"
 #include "sampleutil.h"
 #include "util/cmdlineargs.h"
+#include "engine/sidechain/enginenetworkstream.h"
 
 #ifdef __PORTAUDIO__
 typedef PaError (*SetJackClientName)(const char *name);
@@ -63,6 +64,9 @@ SoundManager::SoundManager(ConfigObject<ConfigValue> *pConfig,
     m_samplerates.push_back(44100);
     m_samplerates.push_back(48000);
     m_samplerates.push_back(96000);
+
+    m_pNetworkStream = QSharedPointer<EngineNetworkStream>(
+            new EngineNetworkStream(2, 0));
 
     queryDevices(); // initializes PortAudio so SMConfig:loadDefaults can do
                     // its thing if it needs to
@@ -280,7 +284,7 @@ void SoundManager::queryDevicesPortaudio() {
 
 void SoundManager::queryDevicesMixxx() {
     SoundDeviceNetwork* currentDevice = new SoundDeviceNetwork(
-            m_pConfig, this, 0);
+            m_pConfig, this, m_pNetworkStream);
     m_devices.push_back(currentDevice);
 }
 

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -110,6 +110,10 @@ class SoundManager : public QObject {
     QList<AudioOutput> registeredOutputs() const;
     QList<AudioInput> registeredInputs() const;
 
+    QSharedPointer<EngineNetworkStream> getNetworkStream() const {
+        return m_pNetworkStream;
+    }
+
   signals:
     void devicesUpdated(); // emitted when pointers to SoundDevices go stale
     void devicesSetup(); // emitted when the sound devices have been set up

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -34,6 +34,7 @@ class AudioInput;
 class AudioSource;
 class AudioDestination;
 class ControlObject;
+class EngineNetworkStream;
 
 #define MIXXX_PORTAUDIO_JACK_STRING "JACK Audio Connection Kit"
 #define MIXXX_PORTAUDIO_ALSA_STRING "ALSA"
@@ -134,6 +135,8 @@ class SoundManager : public QObject {
     QHash<AudioInput, AudioDestination*> m_registeredDestinations;
     ControlObject* m_pControlObjectSoundStatusCO;
     ControlObject* m_pControlObjectVinylControlGainCO;
+
+    QSharedPointer<EngineNetworkStream> m_pNetworkStream;
 };
 
 #endif


### PR DESCRIPTION
This PR connects the EngineNetworkStream to the EngineSchoutcast. 

The next steps might be this: 
- Add a Semaphore to EngineNetworkStream. That is released by the write(), once there is a reasonable amount in the buffer. 
- The EngineSchoutcast has to acquire the seamphore. This will sync the nework stream to the network clock. 
- The buffer has to be compressed and send to the output. Syncing by EngineSchoutcast should be not required, since the Network buffer is already synced to the network time. 
- However, the syncing in ms resolution will not work for low latency settings. We need to figure out how to use a ns time base. 
