### PR TITLE
1.12 shoutcast fixes

### DIFF
--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -131,7 +131,7 @@ void EngineNetworkStream::writeSilence(int frames) {
 void EngineNetworkStream::scheduleWorker() {
     if (m_pOutputFifo->readAvailable()
             >= m_numOutputChannels * kNetworkLatencyFrames) {
-        m_pWorker->outputAvailabe(m_pOutputFifo);
+        m_pWorker->outputAvailabe();
     }
 }
 
@@ -180,4 +180,5 @@ qint64 EngineNetworkStream::getNetworkTimeUs() {
 
 void EngineNetworkStream::addWorker(QSharedPointer<SideChainWorker> pWorker) {
     m_pWorker = pWorker;
+    m_pWorker->setOutputFifo(m_pOutputFifo);
 }

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -166,7 +166,8 @@ void EngineShoutcast::updateFromPreferences() {
     // Convert a bunch of QStrings to QByteArrays so we can get regular C char*
     // strings to pass to libshout.
 
-    QString codec = m_pConfig->getValueString(ConfigKey(SHOUTCAST_PREF_KEY, "metadata_charset"));
+    QString codec = m_pConfig->getValueString(
+            ConfigKey(SHOUTCAST_PREF_KEY, "metadata_charset"));
     QByteArray baCodec = codec.toLatin1();
     m_pTextCodec = QTextCodec::codecForName(baCodec);
     if (!m_pTextCodec) {
@@ -418,15 +419,17 @@ bool EngineShoutcast::serverConnect() {
         sleep(1);
     }
     if (m_iShoutFailures == iMaxTries) {
-        if (m_pShout)
+        if (m_pShout) {
             shout_close(m_pShout);
+        }
         m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY,"enabled"),ConfigValue("0"));
         m_pShoutcastStatus->set(SHOUTCAST_DISCONNECTED);
         return false;
     }
     if (m_bQuit) {
-        if (m_pShout)
+        if (m_pShout) {
             shout_close(m_pShout);
+        }
         m_pShoutcastStatus->set(SHOUTCAST_DISCONNECTED);
         return false;
     }

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -719,9 +719,13 @@ void EngineShoutcast::infoDialog(QString text, QString detailedInfo) {
 }
 
 // Is called from the Mixxx engine thread
-void EngineShoutcast::outputAvailabe(FIFO<CSAMPLE>* pOutputFifo) {
-    m_pOutputFifo = pOutputFifo;
+void EngineShoutcast::outputAvailabe() {
     m_readSema.release();
+}
+
+// Is called from the Mixxx engine thread
+void EngineShoutcast::setOutputFifo(FIFO<CSAMPLE>* pOutputFifo) {
+    m_pOutputFifo = pOutputFifo;
 }
 
 void EngineShoutcast::run() {
@@ -729,17 +733,7 @@ void EngineShoutcast::run() {
     QThread::currentThread()->setObjectName(QString("EngineShoutcast %1").arg(++id));
     qDebug() << "EngineShoutcast::run: starting thread";
 
-    while(1) {
-        if(m_pOutputFifo != NULL && m_pOutputFifo->readAvailable()) {
-            qDebug() << "EngineShoutcast::run: Got output FIFO:" << m_pOutputFifo->readAvailable();
-            break;
-
-        } else {
-            qDebug() << "EngineShoutcast::run: Waiting for output FIFO";
-        }
-        usleep(1000);
-    }
-
+    DEBUG_ASSERT(m_pOutputFifo);
     if (m_pOutputFifo->readAvailable()) {
         m_pOutputFifo->flushReadData(m_pOutputFifo->readAvailable());
     }

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -473,8 +473,9 @@ void EngineShoutcast::write(unsigned char *header, unsigned char *body,
             if (ret != SHOUTERR_SUCCESS) {
                 qDebug() << "DEBUG: Send error: " << shout_get_error(m_pShout);
                 if (m_iShoutFailures > 3) {
-                    if(!serverConnect())
+                    if(!serverConnect()) {
                         errorDialog(tr("Lost connection to streaming server"), tr("Please check your connection to the Internet and verify that your username and password are correct."));
+                    }
                 }
                 else{
                     m_iShoutFailures++;

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -72,7 +72,8 @@ class EngineShoutcast : public QThread, public EncoderCallback, public SideChain
     bool serverDisconnect();
     bool isConnected();
 
-    virtual void outputAvailabe(FIFO<CSAMPLE>* pOutputFifo);
+    virtual void outputAvailabe();
+    virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo);
 
     virtual bool threadWaiting();
 

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -60,7 +60,6 @@ class EngineShoutcast : public QThread, public EncoderCallback, public SideChain
     void process(const CSAMPLE* pBuffer, const int iBufferSize);
 
     void shutdown() {
-        m_bQuit = true;
     }
 
     // Called by the encoder in method 'encodebuffer()' to flush the stream to
@@ -79,11 +78,12 @@ class EngineShoutcast : public QThread, public EncoderCallback, public SideChain
 
     virtual void run();
 
-  public slots:
-    /** Update the libshout struct with info from Mixxx's shoutcast preferences.*/
-    void updateFromPreferences();
-
   private:
+    bool processConnect();
+    void processDisconnect();
+
+    // Update the libshout struct with info from Mixxx's shoutcast preferences.
+    void updateFromPreferences();
     int getActiveTracks();
     // Check if the metadata has changed since the previous check.  We also
     // check when was the last check performed to avoid using too much CPU and
@@ -111,10 +111,8 @@ class EngineShoutcast : public QThread, public EncoderCallback, public SideChain
     ConfigObject<ConfigValue>* m_pConfig;
     Encoder *m_encoder;
     ControlObject* m_pShoutcastNeedUpdateFromPrefs;
-    ControlObjectSlave* m_pUpdateShoutcastFromPrefs;
     ControlObjectSlave* m_pMasterSamplerate;
     ControlObject* m_pShoutcastStatus;
-    volatile bool m_bQuit;
     // static metadata according to prefereneces
     bool m_custom_metadata;
     QString m_customArtist;

--- a/src/engine/sidechain/sidechainworker.h
+++ b/src/engine/sidechain/sidechainworker.h
@@ -10,7 +10,9 @@ class SideChainWorker {
     virtual ~SideChainWorker() { }
     virtual void process(const CSAMPLE* pBuffer, const int iBufferSize) = 0;
     virtual void shutdown() = 0;
-    virtual void outputAvailabe(FIFO<CSAMPLE>* pOutputFifo) {
+    virtual void outputAvailabe() {
+    };
+    virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo) {
         Q_UNUSED(pOutputFifo);
     };
     virtual bool threadWaiting() {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1378,9 +1378,10 @@ void MixxxMainWindow::initActions()
     QString shoutcastText = tr("Stream your mixes to a shoutcast or icecast server");
     m_pOptionsShoutcast = new QAction(shoutcastTitle, this);
     m_pOptionsShoutcast->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
-                                                  "OptionsMenu_EnableLiveBroadcasting"),
-                                                  tr("Ctrl+L"))));
+            QKeySequence(m_pKbdConfig->getValueString(
+                    ConfigKey("[KeyboardShortcuts]",
+                              "OptionsMenu_EnableLiveBroadcasting"),
+                    tr("Ctrl+L"))));
     m_pOptionsShoutcast->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsShoutcast->setCheckable(true);
     m_pOptionsShoutcast->setChecked(m_pShoutcastManager->isEnabled());

--- a/src/shoutcast/shoutcastmanager.cpp
+++ b/src/shoutcast/shoutcastmanager.cpp
@@ -12,10 +12,9 @@ ShoutcastManager::ShoutcastManager(ConfigObject<ConfigValue>* pConfig,
     QSharedPointer<EngineNetworkStream> pNetworkStream =
             pSoundManager->getNetworkStream();
     if (!pNetworkStream.isNull()) {
-        m_pShoutcast = new EngineShoutcast(pConfig);
-        QSharedPointer<SideChainWorker> pWorker(
-                m_pShoutcast);
-        pNetworkStream->addWorker(pWorker);
+        m_pShoutcast = QSharedPointer<SideChainWorker>(
+                new EngineShoutcast(pConfig));
+        pNetworkStream->addWorker(m_pShoutcast);
     }
 }
 

--- a/src/shoutcast/shoutcastmanager.cpp
+++ b/src/shoutcast/shoutcastmanager.cpp
@@ -12,7 +12,7 @@ ShoutcastManager::ShoutcastManager(ConfigObject<ConfigValue>* pConfig,
     QSharedPointer<EngineNetworkStream> pNetworkStream =
             pSoundManager->getNetworkStream();
     if (!pNetworkStream.isNull()) {
-        m_pShoutcast = QSharedPointer<SideChainWorker>(
+        m_pShoutcast = QSharedPointer<EngineShoutcast>(
                 new EngineShoutcast(pConfig));
         pNetworkStream->addWorker(m_pShoutcast);
     }

--- a/src/shoutcast/shoutcastmanager.h
+++ b/src/shoutcast/shoutcastmanager.h
@@ -28,7 +28,7 @@ class ShoutcastManager : public QObject {
 
   private:
     ConfigObject<ConfigValue>* m_pConfig;
-    EngineShoutcast *m_pShoutcast;
+    QSharedPointer<SideChainWorker> m_pShoutcast;
 };
 
 

--- a/src/shoutcast/shoutcastmanager.h
+++ b/src/shoutcast/shoutcastmanager.h
@@ -28,7 +28,7 @@ class ShoutcastManager : public QObject {
 
   private:
     ConfigObject<ConfigValue>* m_pConfig;
-    QSharedPointer<SideChainWorker> m_pShoutcast;
+    QSharedPointer<EngineShoutcast> m_pShoutcast;
 };
 
 

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -26,6 +26,7 @@
 #include "util/defs.h"
 #include "configobject.h"
 #include "soundmanagerconfig.h"
+#include "engine/sidechain/enginenetworkstream.h"
 
 class SoundDevice;
 class EngineMaster;
@@ -34,7 +35,6 @@ class AudioInput;
 class AudioSource;
 class AudioDestination;
 class ControlObject;
-class EngineNetworkStream;
 
 #define MIXXX_PORTAUDIO_JACK_STRING "JACK Audio Connection Kit"
 #define MIXXX_PORTAUDIO_ALSA_STRING "ALSA"


### PR DESCRIPTION
This may work, but it is quite dirty. 
I have moved all libshout calls to the shout thread. 
The shoutcast manager is the right instance to start and stop the shoutcast thread. 
I think we have to turn the "enabled" config into a CO and choose a better naming for the functions.
The error handling is also not it place. 
