### PR TITLE
Fix compile on WIN, use GetSystemTimePreciseAsFileTime() on Windows 8

### DIFF
--- a/src/dlgprefshoutcast.cpp
+++ b/src/dlgprefshoutcast.cpp
@@ -277,6 +277,6 @@ void DlgPrefShoutcast::slotApply()
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "custom_title"),  ConfigValue(custom_title->text()));
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "metadata_format"), ConfigValue(metadata_format->text()));
 
-    //Tell the EngineShoutcast object to update with these values by toggling this control object.
+    // Tell the EngineShoutcast object to update with these values by toggling this control object.
     m_pUpdateShoutcastFromPrefs->set(1.0);
 }

--- a/src/dlgprefshoutcast.cpp
+++ b/src/dlgprefshoutcast.cpp
@@ -22,7 +22,7 @@
 #include "defs_urls.h"
 #include "dlgprefshoutcast.h"
 #include "shoutcast/defs_shoutcast.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 
 const char* kDefaultMetadataFormat = "$artist - $title";
 
@@ -31,12 +31,14 @@ DlgPrefShoutcast::DlgPrefShoutcast(QWidget *parent, ConfigObject<ConfigValue> *_
           m_pConfig(_config) {
     setupUi(this);
 
-    m_pUpdateShoutcastFromPrefs = new ControlObjectThread(
-            SHOUTCAST_PREF_KEY, "update_from_prefs");
+    m_pUpdateShoutcastFromPrefs = new ControlObjectSlave(
+            SHOUTCAST_PREF_KEY, "update_from_prefs", this);
+    m_pShoutcastEnabled = new ControlObjectSlave(
+            SHOUTCAST_PREF_KEY, "enabled", this);
 
     // Enable live broadcasting checkbox
-    enableLiveBroadcasting->setChecked((bool)m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY,"enabled")).toInt());
+    enableLiveBroadcasting->setChecked(
+            m_pShoutcastEnabled->toBool());
 
     //Server type combobox
     comboBoxServerType->addItem(tr("Icecast 2"), SHOUTCAST_SERVER_ICECAST2);
@@ -181,7 +183,6 @@ DlgPrefShoutcast::DlgPrefShoutcast(QWidget *parent, ConfigObject<ConfigValue> *_
 }
 
 DlgPrefShoutcast::~DlgPrefShoutcast() {
-    delete m_pUpdateShoutcastFromPrefs;
 }
 
 void DlgPrefShoutcast::slotResetToDefaults() {
@@ -212,31 +213,49 @@ void DlgPrefShoutcast::slotResetToDefaults() {
 }
 
 void DlgPrefShoutcast::slotUpdate() {
-    enableLiveBroadcasting->setChecked((bool)m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY,"enabled")).toInt());
+    enableLiveBroadcasting->setChecked(m_pShoutcastEnabled->toBool());
 }
 
 void DlgPrefShoutcast::slotApply()
 {
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "enabled"),       ConfigValue(enableLiveBroadcasting->isChecked()));
+    m_pShoutcastEnabled->set(enableLiveBroadcasting->isChecked());
 
     // Combo boxes, make sure to load their data not their display strings.
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "servertype"),    ConfigValue(comboBoxServerType->itemData(comboBoxServerType->currentIndex()).toString()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "bitrate"),       ConfigValue(comboBoxEncodingBitrate->itemData(comboBoxEncodingBitrate->currentIndex()).toString()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "format"),        ConfigValue(comboBoxEncodingFormat->itemData(comboBoxEncodingFormat->currentIndex()).toString()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "channels"),      ConfigValue(comboBoxEncodingChannels->itemData(comboBoxEncodingChannels->currentIndex()).toString()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "servertype"),
+            ConfigValue(comboBoxServerType->itemData(
+                            comboBoxServerType->currentIndex()).toString()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "bitrate"),
+            ConfigValue(comboBoxEncodingBitrate->itemData(
+                            comboBoxEncodingBitrate->currentIndex()).toString()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "format"),
+            ConfigValue(comboBoxEncodingFormat->itemData(
+                            comboBoxEncodingFormat->currentIndex()).toString()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "channels"),
+            ConfigValue(comboBoxEncodingChannels->itemData(
+                            comboBoxEncodingChannels->currentIndex()).toString()));
 
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "mountpoint"),    ConfigValue(mountpoint->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "host"),          ConfigValue(host->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "port"),          ConfigValue(port->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "login"),         ConfigValue(login->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "password"),      ConfigValue(password->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_name"),   ConfigValue(stream_name->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_website"),ConfigValue(stream_website->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_desc"),   ConfigValue(stream_desc->toPlainText()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_genre"),  ConfigValue(stream_genre->text()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_public"), ConfigValue(stream_public->isChecked()));
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "ogg_dynamicupdate"), ConfigValue(ogg_dynamicupdate->isChecked()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "mountpoint"),
+            ConfigValue(mountpoint->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "host"),
+            ConfigValue(host->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "port"),
+            ConfigValue(port->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "login"),
+            ConfigValue(login->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "password"),
+            ConfigValue(password->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_name"),
+            ConfigValue(stream_name->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_website"),
+            ConfigValue(stream_website->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_desc"),
+            ConfigValue(stream_desc->toPlainText()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_genre"),
+            ConfigValue(stream_genre->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "stream_public"),
+            ConfigValue(stream_public->isChecked()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "ogg_dynamicupdate"),
+            ConfigValue(ogg_dynamicupdate->isChecked()));
 
     QString charset = "";
     if (enableUtf8Metadata->isChecked()) {
@@ -259,5 +278,5 @@ void DlgPrefShoutcast::slotApply()
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "metadata_format"), ConfigValue(metadata_format->text()));
 
     //Tell the EngineShoutcast object to update with these values by toggling this control object.
-    m_pUpdateShoutcastFromPrefs->slotSet(1.0);
+    m_pUpdateShoutcastFromPrefs->set(1.0);
 }

--- a/src/dlgprefshoutcast.h
+++ b/src/dlgprefshoutcast.h
@@ -32,7 +32,7 @@
   *@author John Sully
   */
 
-class ControlObjectThread;
+class ControlObjectSlave;
 
 class DlgPrefShoutcast : public DlgPreferencePage, public Ui::DlgPrefShoutcastDlg  {
     Q_OBJECT
@@ -52,7 +52,8 @@ class DlgPrefShoutcast : public DlgPreferencePage, public Ui::DlgPrefShoutcastDl
   private:
     ConfigObject<ConfigValue>* m_pConfig;
     // If set to 1, EngineShoutcast will update it's settings.
-    ControlObjectThread* m_pUpdateShoutcastFromPrefs;
+    ControlObjectSlave* m_pUpdateShoutcastFromPrefs;
+    ControlObjectSlave* m_pShoutcastEnabled;
 };
 
 #endif

--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -228,7 +228,7 @@ qint64 EngineNetworkStream::getNetworkTimeUs() {
 #endif
 }
 
-void EngineNetworkStream::addWorker(QSharedPointer<SideChainWorker> pWorker) {
+void EngineNetworkStream::addWorker(QSharedPointer<NetworkStreamWorker> pWorker) {
     m_pWorker = pWorker;
     m_pWorker->setOutputFifo(m_pOutputFifo);
 }

--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -153,7 +153,7 @@ void EngineNetworkStream::writeSilence(int frames) {
 void EngineNetworkStream::scheduleWorker() {
     if (m_pOutputFifo->readAvailable()
             >= m_numOutputChannels * kNetworkLatencyFrames) {
-        m_pWorker->outputAvailabe();
+        m_pWorker->outputAvailable();
     }
 }
 
@@ -186,7 +186,7 @@ qint64 EngineNetworkStream::getStreamTimeUs() {
 qint64 EngineNetworkStream::getNetworkTimeUs() {
     // This matches the GPL2 implementation found in
     // https://github.com/codders/libshout/blob/a17fb84671d3732317b0353d7281cc47e2df6cf6/src/timing/timing.c
-    // Instead of ms resuolution we use a us resolution to allow low latency settings
+    // Instead of ms resolution we use a us resolution to allow low latency settings
     // will overflow > 200,000 years
 #ifdef __WINDOWS__
     FILETIME ft;

--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -168,13 +168,20 @@ qint64 EngineNetworkStream::getNetworkTimeUs() {
     // will overflow > 200,000 years
 #ifdef __WINDOWS__
     FILETIME ft;
-    int64_t t;
+    qint64 t;
+
+#if defined(NTDDI_WIN8) && NTDDI_VERSION >= NTDDI_WIN8
+    // Windows 8, Windows Server 2012 and later.
+    GetSystemTimePreciseAsFileTime(&ft);
+#else
+    // Windows 2000 and later
     GetSystemTimeAsFileTime(&ft);
+#endif
     return ((qint64)ft.dwHighDateTime << 32 | ft.dwLowDateTime) / 10;
 #else
-    struct timeval mtv;
-    gettimeofday(&mtv, NULL);
-    return (qint64)(mtv.tv_sec) * 1000000 + mtv.tv_usec;
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
 #endif
 }
 

--- a/src/engine/sidechain/enginenetworkstream.h
+++ b/src/engine/sidechain/enginenetworkstream.h
@@ -3,7 +3,7 @@
 
 #include "util/types.h"
 #include "util/fifo.h"
-#include "engine/sidechain/sidechainworker.h"
+#include "engine/sidechain/networkstreamworker.h"
 
 class EngineNetworkStream {
   public:
@@ -34,7 +34,7 @@ class EngineNetworkStream {
 
     static qint64 getNetworkTimeUs();
 
-    void addWorker(QSharedPointer<SideChainWorker> pWorker);
+    void addWorker(QSharedPointer<NetworkStreamWorker> pWorker);
 
   private:
     void scheduleWorker();
@@ -47,7 +47,7 @@ class EngineNetworkStream {
     qint64 m_streamStartTimeUs;
     qint64 m_streamFramesWritten;
     qint64 m_streamFramesRead;
-    QSharedPointer<SideChainWorker> m_pWorker;
+    QSharedPointer<NetworkStreamWorker> m_pWorker;
     int m_writeOverflowCount;
 };
 

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -764,7 +764,7 @@ void EngineShoutcast::run() {
                     &dataPtr2, &size2);
             process(dataPtr1, size1);
             if (size2 > 0) {
-                process(dataPtr1, size2);
+                process(dataPtr2, size2);
             }
             m_pOutputFifo->releaseReadRegions(readAvailable);
         }

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -716,7 +716,7 @@ void EngineShoutcast::infoDialog(QString text, QString detailedInfo) {
 }
 
 // Is called from the Mixxx engine thread
-void EngineShoutcast::outputAvailabe() {
+void EngineShoutcast::outputAvailable() {
     m_readSema.release();
 }
 

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -734,7 +734,9 @@ void EngineShoutcast::run() {
     processConnect();
 
     setState(SIDECHAINWORKER_STATE_WAITING);
-    DEBUG_ASSERT(m_pOutputFifo);
+    DEBUG_ASSERT_AND_HANDLE(m_pOutputFifo) {
+        return;
+    }
     if (m_pOutputFifo->readAvailable()) {
         m_pOutputFifo->flushReadData(m_pOutputFifo->readAvailable());
     }

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -31,7 +31,7 @@
 #include "controlobjectthread.h"
 #include "controlobjectslave.h"
 #include "encoder/encodercallback.h"
-#include "engine/sidechain/sidechainworker.h"
+#include "engine/sidechain/networkstreamworker.h"
 #include "errordialoghandler.h"
 #include "trackinfoobject.h"
 #include "util/fifo.h"
@@ -45,7 +45,8 @@ typedef struct shout shout_t;
 struct _util_dict;
 typedef struct _util_dict shout_metadata_t;
 
-class EngineShoutcast : public QThread, public EncoderCallback, public SideChainWorker {
+class EngineShoutcast :
+        public QThread, public EncoderCallback, public NetworkStreamWorker {
     Q_OBJECT
   public:
     EngineShoutcast(ConfigObject<ConfigValue>* _config);

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -67,7 +67,7 @@ class EngineShoutcast : public QThread, public EncoderCallback, public SideChain
     bool serverDisconnect();
     bool isConnected();
 
-    virtual void outputAvailabe();
+    virtual void outputAvailable();
     virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo);
 
     virtual bool threadWaiting();

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -108,6 +108,7 @@ class EngineShoutcast :
     ConfigObject<ConfigValue>* m_pConfig;
     Encoder *m_encoder;
     ControlObject* m_pShoutcastNeedUpdateFromPrefs;
+    ControlObject* m_pShoutcastEnabled;
     ControlObjectSlave* m_pMasterSamplerate;
     ControlObject* m_pShoutcastStatus;
     // static metadata according to prefereneces

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -126,7 +126,7 @@ class EngineShoutcast : public QThread, public EncoderCallback, public SideChain
     bool m_protocol_is_shoutcast;
     bool m_ogg_dynamic_update;
     QVector<struct shoutcastCacheObject  *> m_pShoutcastCache;
-    bool m_bThreadQuit;
+    volatile bool m_bThreadQuit;
     QAtomicInt m_threadWaiting;
     QSemaphore m_readSema;
     FIFO<CSAMPLE>* m_pOutputFifo;

--- a/src/engine/sidechain/sidechainworker.h
+++ b/src/engine/sidechain/sidechainworker.h
@@ -46,7 +46,7 @@ class SideChainWorker {
     virtual ~SideChainWorker() { }
     virtual void process(const CSAMPLE* pBuffer, const int iBufferSize) = 0;
     virtual void shutdown() = 0;
-    virtual void outputAvailabe() {
+    virtual void outputAvailable() {
     };
     virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo) {
         Q_UNUSED(pOutputFifo);

--- a/src/engine/sidechain/sidechainworker.h
+++ b/src/engine/sidechain/sidechainworker.h
@@ -2,67 +2,13 @@
 #define SIDECHAINWORKER_H
 
 #include "util/types.h"
-#include "util/fifo.h"
-
-/*
- * States:
- * Error        Something errornous has happenned and can't go on
- * New          First state before init
- * Init         Initing state don't feed anything in this state
- * Waiting      Waiting something not ready yet
- * Busy         Is busy doing something can't process anything new
- * Ready        Functioning ok
- * Reading      Reading something and can't do anything else
- * Writing      Writing something and can't do anything else
- * Connected    Is connected to storage or server
- * Connecting   Trying to connect storate or server
- * Disconnected Ain't connected to storage or server
- * 
- * First state should be SIDECHAINWORKER_STATE_UNKNOWN and
- * if state handling ain't supported by SideChainWorker-class
- * then 'SIDECHAINWORKER_STATE_NEW' should be treated as
- * SIDECHAINWORKER_STATE_READY. Newly written SideChainWorker-class
- * should support state handling at leas this SIDECHAINWORKER_STATE_READY state.
- */
-
-enum SidechaingStates {
-    SIDECHAINWORKER_STATE_ERROR = -1,
-    SIDECHAINWORKER_STATE_NEW,
-    SIDECHAINWORKER_STATE_INIT,
-    SIDECHAINWORKER_STATE_WAITING,
-    SIDECHAINWORKER_STATE_BUSY,
-    SIDECHAINWORKER_STATE_READY,
-    SIDECHAINWORKER_STATE_READING,
-    SIDECHAINWORKER_STATE_WRITING,
-    SICECHAINWORKER_STATE_CONNECTED,
-    SICECHAINWORKER_STATE_CONNECTING,
-    SIDECHAINWORKER_STATE_DISCONNECTED
-};
 
 class SideChainWorker {
   public:
-    SideChainWorker() :
-    m_iSideChainWorkerState(SIDECHAINWORKER_STATE_NEW) { }
+    SideChainWorker() { }
     virtual ~SideChainWorker() { }
     virtual void process(const CSAMPLE* pBuffer, const int iBufferSize) = 0;
     virtual void shutdown() = 0;
-    virtual void outputAvailable() {
-    };
-    virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo) {
-        Q_UNUSED(pOutputFifo);
-    };
-    virtual bool threadWaiting() {
-        return false;
-    }
-    virtual int getState() {
-        return m_iSideChainWorkerState;
-    }
-protected:
-    virtual void setState(int state) {
-        m_iSideChainWorkerState = state;
-    }
-private:
-    int m_iSideChainWorkerState;
 };
 
 #endif /* SIDECHAINWORKER_H */

--- a/src/shoutcast/shoutcastmanager.cpp
+++ b/src/shoutcast/shoutcastmanager.cpp
@@ -16,20 +16,18 @@ ShoutcastManager::ShoutcastManager(ConfigObject<ConfigValue>* pConfig,
                 new EngineShoutcast(pConfig));
         pNetworkStream->addWorker(m_pShoutcast);
     }
+    m_pShoutcastEnabled = new ControlObjectSlave(
+            SHOUTCAST_PREF_KEY, "enabled", this);
 }
 
 ShoutcastManager::~ShoutcastManager() {
     // Disable shoutcast so when Mixxx starts again it will not connect.
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "enabled"), 0);
+    m_pShoutcastEnabled->set(0);
 }
 
 void ShoutcastManager::setEnabled(bool value) {
-    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "enabled"),
-                   ConfigValue(value));
-
-    /**
-     *  Should this be started somewhere else?
-     */
+    m_pShoutcastEnabled->set(value);
+    //  Should this be started somewhere else?
     if (value == true) {
         m_pShoutcast->serverConnect();
     } else {
@@ -38,6 +36,5 @@ void ShoutcastManager::setEnabled(bool value) {
 }
 
 bool ShoutcastManager::isEnabled() {
-    return m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "enabled")).toInt() == 1;
+    return m_pShoutcastEnabled->toBool();
 }

--- a/src/shoutcast/shoutcastmanager.h
+++ b/src/shoutcast/shoutcastmanager.h
@@ -29,6 +29,7 @@ class ShoutcastManager : public QObject {
   private:
     ConfigObject<ConfigValue>* m_pConfig;
     QSharedPointer<EngineShoutcast> m_pShoutcast;
+    ControlObjectSlave* m_pShoutcastEnabled;
 };
 
 


### PR DESCRIPTION
This PR should fix compiling on Windows.

Currently the network buffer is still synced by the system timers, this will be switched to the master reference clock in one of the later commits 
